### PR TITLE
Add Shopify theme export and live data integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "electron": "^27.0.0",
+        "file-saver": "^2.0.5",
         "grapesjs": "^0.21.5",
+        "grapesjs-blocks-basic": "^1.0.2",
+        "jszip": "^3.10.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1602,6 +1605,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -1937,6 +1946,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -2195,6 +2210,12 @@
         "underscore": "1.13.1"
       }
     },
+    "node_modules/grapesjs-blocks-basic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/grapesjs-blocks-basic/-/grapesjs-blocks-basic-1.0.2.tgz",
+      "integrity": "sha512-SsPKf/CvQkZ+kABOsN01auAPHXh/2J20g0AWYF7fHR3Gw3TZLtdIxT1mk90Qzi76u/7sUYi3CTI+i3ZaTtXHRA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2279,6 +2300,18 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2288,6 +2321,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/joi": {
       "version": "17.13.3",
@@ -2357,6 +2396,18 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2364,6 +2415,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lodash": {
@@ -2541,6 +2601,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -2582,6 +2648,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -2660,6 +2732,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/require-directory": {
@@ -2758,6 +2845,12 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2799,6 +2892,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -2834,6 +2933,15 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2972,6 +3080,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.19",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,11 @@
   "dependencies": {
     "electron": "^27.0.0",
     "grapesjs": "^0.21.5",
+    "grapesjs-blocks-basic": "^1.0.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "jszip": "^3.10.1",
+    "file-saver": "^2.0.5"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect } from 'react';
 import grapesjs from 'grapesjs';
 import 'grapesjs/dist/css/grapes.min.css';
+import basicBlocks from 'grapesjs-blocks-basic';
+import { saveAs } from 'file-saver';
+import { generateThemeZip } from './themeGenerator';
+import { fetchProducts } from './shopify';
 
 export default function App() {
   useEffect(() => {
@@ -8,8 +12,35 @@ export default function App() {
       container: '#gjs',
       height: '100%',
       storageManager: false,
-      plugins: [],
+      plugins: [basicBlocks],
+      deviceManager: {
+        devices: [
+          { name: 'Desktop', width: '' },
+          { name: 'Tablet', width: '768px' },
+          { name: 'Mobile', width: '320px' },
+        ],
+      },
     });
+
+    editor.Panels.addButton('options', {
+      id: 'export-theme',
+      className: 'fa fa-download',
+      command: 'export-theme',
+      attributes: { title: 'Export Shopify Theme' },
+    });
+
+    editor.Commands.add('export-theme', {
+      run: async (ed) => {
+        const zip = await generateThemeZip(ed);
+        saveAs(zip, 'shopify-theme.zip');
+      },
+    });
+
+    // Example of live store integration
+    fetchProducts().then((prods) => {
+      console.log(`Loaded ${prods.length} products from store`);
+    }).catch(console.error);
+
     return () => editor.destroy();
   }, []);
 

--- a/src/shopify.js
+++ b/src/shopify.js
@@ -1,6 +1,34 @@
-// Placeholder Shopify API integration.
-// Real implementation requires OAuth and API requests.
+const API_VERSION = import.meta.env.VITE_SHOPIFY_API_VERSION || '2023-10';
+const STORE_DOMAIN = import.meta.env.VITE_SHOPIFY_STORE;
+const ADMIN_TOKEN = import.meta.env.VITE_SHOPIFY_ADMIN_TOKEN;
+
+async function shopifyFetch(path) {
+  if (!STORE_DOMAIN || !ADMIN_TOKEN) {
+    throw new Error('Missing Shopify store credentials');
+  }
+  const res = await fetch(`https://${STORE_DOMAIN}/admin/api/${API_VERSION}/${path}`, {
+    headers: {
+      'X-Shopify-Access-Token': ADMIN_TOKEN,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Shopify request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 export async function fetchProducts() {
-  // TODO: implement Shopify product fetch
-  return [];
+  const data = await shopifyFetch('products.json');
+  return data.products || [];
+}
+
+export async function fetchCollections() {
+  const data = await shopifyFetch('collections.json');
+  return data.collections || [];
+}
+
+export async function fetchShopInfo() {
+  const data = await shopifyFetch('shop.json');
+  return data.shop || {};
 }

--- a/src/themeGenerator.js
+++ b/src/themeGenerator.js
@@ -1,0 +1,31 @@
+import JSZip from 'jszip';
+
+// Generate a minimal Shopify theme ZIP from the current GrapesJS editor state
+export async function generateThemeZip(editor) {
+  const zip = new JSZip();
+
+  // Gather HTML and CSS from editor
+  const html = editor.getHtml();
+  const css = editor.getCss();
+
+  // Basic theme files
+  zip.file(
+    'layout/theme.liquid',
+    `<!doctype html>\n<html lang="en">\n<head>\n  {{ content_for_header }}\n  <link rel="stylesheet" href="{{ 'theme.css' | asset_url }}">\n</head>\n<body>\n  {{ content_for_layout }}\n  <script src="{{ 'theme.js' | asset_url }}"></script>\n</body>\n</html>`
+  );
+
+  // Page template using the editor markup
+  zip.file(
+    'templates/index.liquid',
+    html
+  );
+
+  // Assets collected from editor
+  zip.file('assets/theme.css', css);
+  zip.file('assets/theme.js', '');
+
+  // Minimal settings file
+  zip.file('config/settings_schema.json', '[]');
+
+  return zip.generateAsync({ type: 'blob' });
+}


### PR DESCRIPTION
## Summary
- integrate Shopify REST API helpers for products, collections, and shop info
- enhance GrapesJS editor with responsive devices and theme export button
- generate minimal Shopify theme zip from editor output

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898164551288331a72b3f777c83f744